### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paul80nd/rcasm/security/code-scanning/2](https://github.com/paul80nd/rcasm/security/code-scanning/2)

To fix the issue, we should add an explicit `permissions` block to the workflow. The minimal required permission for typical CI jobs (which only need to clone/read repository contents) is `contents: read`. This permissions block can be placed at the top of the file after the `name:` and before the `on:` block for root-level effect, or just above the job under `build:` for job-level effect. The single best way, for clarity and coverage, is to place it at the workflow root (after `name: CI` and before `on:`), so that all jobs in the workflow default to least privilege. No additional imports or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
