### PR TITLE
update typedfastbitset to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.20.0",
       "license": "MIT",
       "dependencies": {
-        "typedfastbitset": "^0.6.1"
+        "typedfastbitset": "^0.8.0"
       },
       "devDependencies": {
         "@types/mocha": "10.0.10",
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/typedfastbitset": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/typedfastbitset/-/typedfastbitset-0.6.1.tgz",
-      "integrity": "sha512-+RP2jdehXs774+lqiuqg/g9DcmPeCdWS8atagWb/iZf+pY6BDG2mH5WwBES6nqKXh3QSt4dJjmwoOsJq3iSWRA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/typedfastbitset/-/typedfastbitset-0.8.0.tgz",
+      "integrity": "sha512-GLGi9mkz4iQEzfujD6qFeu2G5HlPyevAPQfyo48zGDsF7BATg9HEcXqIwZg/HbM7RTN/96SppVGk3DtSFumo4w==",
       "license": "Apache-2.0"
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "tsc --watch -p ."
   },
   "dependencies": {
-    "typedfastbitset": "^0.6.1"
+    "typedfastbitset": "^0.8.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.10",


### PR DESCRIPTION
## Summary
- Bumps the only runtime dependency, `typedfastbitset`, from 0.6.1 → 0.8.0
- 0.7.0 was a bug fix; 0.8.0 is an internal performance refactor (PR upstream #39 separates logical word count from buffer capacity)
- Public API used here (`new TypedFastBitSet()`, `.add`, `.has`, `.clone`) is unchanged — verified against the published `.d.ts` for both versions

## Test plan
- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm test` — all 95 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)